### PR TITLE
[fix/1] trigger input events to prevent React from reverting text cha…

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -47,6 +47,16 @@ function getAllowedDomains() {
           
           textarea.value = politeText;
           textarea.textContent = politeText;
+          
+          // Trigger React's synthetic events to update React's internal state
+          // This prevents React from restoring the original value on re-render
+          // React listens to 'input' events for controlled components
+          const inputEvent = new Event('input', { bubbles: true, cancelable: true });
+          textarea.dispatchEvent(inputEvent);
+          
+          // Also trigger 'change' event for compatibility
+          const changeEvent = new Event('change', { bubbles: true, cancelable: true });
+          textarea.dispatchEvent(changeEvent);
         } else {
           showError(button, result.error || 'Could not rewrite.');
         }
@@ -103,3 +113,4 @@ function getAllowedDomains() {
     run();
   }
 })();
+


### PR DESCRIPTION
This PR addresses the state synchronization issue described in #1.

When updating the comment textarea programmatically, React's internal state was not picking up the manual DOM changes, causing the text to revert to an older draft upon re-render. By explicitly dispatching input and change events, we trigger React's synthetic event system to ensure the state stays in sync with the UI.

Fixes #1

**Changes**

1. Manual Event Dispatching: Dispatches a bubbling input event so React’s controlled component logic recognizes the value change.

2. Compatibility: Includes a change event dispatch to support broader event listener compatibility.

3. Draft Persistence: Ensures that once a draft is injected, React acknowledges it as the current state, preventing it from being overwritten.

**Technical Detail**
Because React manages the textarea as a controlled component, direct manipulation of textarea.value is "invisible" to the virtual DOM. Manually triggering these events forces React to run its internal update cycle.